### PR TITLE
refactored package name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>org.goldendogconsulting.WordWheelCommandLine</mainClass>
+                            <mainClass>uk.org.goldendogconsulting.WordWheelCommandLine</mainClass>
                         </manifest>
                     </archive>
                 </configuration>
@@ -115,7 +115,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>org.goldendogconsulting.WordWheelCommandLine</mainClass>
+                            <mainClass>uk.org.goldendogconsulting.WordWheelCommandLine</mainClass>
                         </manifest>
                     </archive>
                     <descriptorRefs>

--- a/src/main/java/uk/org/goldendogconsulting/FindCombination.java
+++ b/src/main/java/uk/org/goldendogconsulting/FindCombination.java
@@ -1,4 +1,4 @@
-package org.goldendogconsulting;
+package uk.org.goldendogconsulting;
 
 import java.util.Set;
 import java.util.concurrent.Callable;

--- a/src/main/java/uk/org/goldendogconsulting/PermutateStringException.java
+++ b/src/main/java/uk/org/goldendogconsulting/PermutateStringException.java
@@ -1,4 +1,4 @@
-package org.goldendogconsulting;
+package uk.org.goldendogconsulting;
 
 public class PermutateStringException extends Exception{
     public PermutateStringException(String s) {

--- a/src/main/java/uk/org/goldendogconsulting/WordWheel.java
+++ b/src/main/java/uk/org/goldendogconsulting/WordWheel.java
@@ -1,4 +1,4 @@
-package org.goldendogconsulting;
+package uk.org.goldendogconsulting;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/uk/org/goldendogconsulting/WordWheelCommandLine.java
+++ b/src/main/java/uk/org/goldendogconsulting/WordWheelCommandLine.java
@@ -1,4 +1,4 @@
-package org.goldendogconsulting;
+package uk.org.goldendogconsulting;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;

--- a/src/test/java/uk/org/goldendogconsulting/WordWheelTest.java
+++ b/src/test/java/uk/org/goldendogconsulting/WordWheelTest.java
@@ -1,4 +1,4 @@
-package org.goldendogconsulting;
+package uk.org.goldendogconsulting;
 
 import junit.framework.TestCase;
 import org.apache.logging.log4j.LogManager;


### PR DESCRIPTION
was org.goldendogconsulting, but the domain was incorrect, should be uk.org.opendogconsulting. 
This package rename/refactor corrects this